### PR TITLE
ver0.9.5

### DIFF
--- a/SynicSugar/Assets/SynicSugar/Runtime/MatchMake/EOS/EOSMatchmaking.cs
+++ b/SynicSugar/Assets/SynicSugar/Runtime/MatchMake/EOS/EOSMatchmaking.cs
@@ -77,6 +77,7 @@ namespace SynicSugar.MatchMake {
             //If player cannot join lobby as a guest, creates a lobby as a host and waits for other player.
             //Create
             Result createResult = await CreateLobby(lobbyCondition, userAttributes, token);
+
             if(createResult == Result.Success){
                 // Wait for establised matchmaking and to get SocketName to be used in p2p connection.
                 Result matchingResult = await WaitForMatchingEstablishment(token);
@@ -222,7 +223,6 @@ namespace SynicSugar.MatchMake {
                 Debug.LogError("Create Lobby: can't add lobby search attributes.");
                 return modifyAttribute;
             }
-            
             return modifyAttribute;
 
             void OnCreateLobbyCompleted(ref CreateLobbyCallbackInfo info){
@@ -404,12 +404,12 @@ namespace SynicSugar.MatchMake {
                 if(!MatchMakeManager.Instance.isLooking){
                     return Result.Canceled;
                 }
-
+                
                 //Timeout or User cancels Matchmaking process from token.
                 if(MatchMakeManager.Instance.enableHostmigrationInMatchmaking){
-                    await CancelMatchMaking(token);
+                    await CancelMatchMaking(MatchMakeManager.Instance.GetCancellationTokenOnDestroy());
                 }else{
-                    await CloseMatchMaking(token);
+                    await CloseMatchMaking(MatchMakeManager.Instance.GetCancellationTokenOnDestroy());
                 }
                 //Need to clear GUI state for Timeout.
                 foreach(var member in CurrentLobby.Members){

--- a/SynicSugar/Assets/SynicSugar/Runtime/MatchMake/EOS/EOSMatchmaking.cs
+++ b/SynicSugar/Assets/SynicSugar/Runtime/MatchMake/EOS/EOSMatchmaking.cs
@@ -126,7 +126,7 @@ namespace SynicSugar.MatchMake {
             requiredMembers = minLobbyMember;
 
             Result createResult = await CreateLobby(lobbyCondition, userAttributes, token);
-            
+
             if(createResult == Result.Success){
                 // Wait for establised matchmaking and to get SocketName to be used in p2p connection.
                 Result matchingResult = await WaitForMatchingEstablishment(token);
@@ -400,6 +400,7 @@ namespace SynicSugar.MatchMake {
                 return matchingResult;
             }
             catch (OperationCanceledException){
+                MatchMakeManager.Instance.MatchMakingGUIEvents.ChangeState(MatchMakingGUIEvents.State.Cancel);
                 //User cancels Matchmaking process from cancel APIs.
                 if(!MatchMakeManager.Instance.isLooking){
                     return Result.Canceled;

--- a/SynicSugar/Assets/SynicSugar/Runtime/MatchMake/MatchMakeManager.cs
+++ b/SynicSugar/Assets/SynicSugar/Runtime/MatchMake/MatchMakeManager.cs
@@ -515,7 +515,6 @@ namespace SynicSugar.MatchMake {
                     Debug.Log("Cancel matching by timeout");
                 #endif
                     matchmakeTokenSource?.Cancel();
-                    isLooking = false;
                 }
             }
             catch (OperationCanceledException){ // Cancel matchmaking process by user from library outside.
@@ -527,7 +526,6 @@ namespace SynicSugar.MatchMake {
                 }
             #endif
                 timeUntilTimeout = 0f;
-                matchmakeTokenSource?.Cancel();
             }
         #if SYNICSUGAR_LOG
             Debug.Log("TimeoutTimer: Stop timeout timer for looking opponents.");

--- a/SynicSugar/Assets/SynicSugar/Runtime/MatchMake/MatchMakeManager.cs
+++ b/SynicSugar/Assets/SynicSugar/Runtime/MatchMake/MatchMakeManager.cs
@@ -431,7 +431,7 @@ namespace SynicSugar.MatchMake {
             TimeoutTimer(timeoutSec, token).Forget();
 
             try{
-                Result result = await matchmakingCore.StartJustCreate(lobbyCondition, userAttributes, minLobbyMember, token);
+                Result result = await matchmakingCore.StartJustCreate(lobbyCondition, userAttributes, minLobbyMember, matchmakeTokenSource.Token);
                 isLooking = false;
                 return result;
             }catch(OperationCanceledException){

--- a/SynicSugar/Assets/SynicSugar/package.json
+++ b/SynicSugar/Assets/SynicSugar/package.json
@@ -2,7 +2,7 @@
 {
   "name": "net.skeyll.synicsugar",
   "displayName": "SynicSugar",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "unity": "2021.3",
   "description": "High-level Networking Library for Mobile and Small-party Games with Epic Online Services.",
   "keywords": ["Network", "Services"],


### PR DESCRIPTION
Add
Invoke Cancel event registered as GUI event before timeout process.

Fix
Stop setting isLooking to false in the timeout timer.
Fixed that CreateLobby was passing the timer's token instead of the matchmaking token.
Fixed issue of using canceled cancel token in timeout processing.